### PR TITLE
Add gitignore for OS and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# OS files
+.DS_Store
+
+# Node modules
+node_modules/
+
+# Build output
+dist/


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude OS files and common build folders

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68474f046938832f8e8c99d67628148d