### PR TITLE
Add service worker for offline caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,5 +1004,6 @@
             initGame();
         });
     </script>
+    <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,41 @@
+const CACHE_NAME = 'elonmusksimulator-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/questions.js',
+  '/new_questions_batch1.js',
+  '/new_questions_batch2.js',
+  '/new_questions_batch3.js',
+  '/new_questions_batch4.js',
+  '/new_questions_batch5.js',
+  '/normalize_questions.js',
+  '/elon_musk_angry.png',
+  '/elon_musk_cartoon.png',
+  '/elon_musk_happy.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => {
+      return cache.addAll(urlsToCache);
+    })
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- cache game assets with a new `sw.js`
- register service worker via `main.js`
- load `main.js` from `index.html`

## Testing
- `node` was not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68474f0729d8832f9a29b1faab30176b