### PR TITLE
Improve README with overview and SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
 # Elon Musk Simulator
 
-**Elon Musk Simulator** is a tongue-in-cheek browser game where you try to keep Elon's many ventures afloat. Each turn presents a question with absurd proposals. Swipe **left** or **right** to answer and balance the vital stats for SpaceX, Tesla, and other Musk projects. Let any vital reach 0 or 100 and it's game over!
+**Elon Musk Simulator** is a short satirical web game where you juggle the many businesses and whims of a fictionalized Elon Musk. Swipe **left** or **right** on ridiculous proposals to keep the different project "vitals" in balance. If any meter hits 0 or 100, it's game over.
 
-## Playing the Game
+This game is purely a parody created for entertainment and is not affiliated with Elon Musk or his companies.
+
+## Gameplay
+Each turn presents a question card. Swiping right accepts the idea, swiping left rejects it. Your choice alters the stats for SpaceX, Tesla, public opinion, and other ventures. Survive as long as possible without any vital running dry or overflowing.
+
+## Run the Game Locally
 1. Clone or download this repository.
-2. Open `index.html` in a modern web browser (double click the file or serve it locally).
-3. Drag/swipe the card left or right to pick an answer. Keep the meters from maxing out or dropping to zero to survive.
-4. If you fail, hit **Try Again** or **Quit** to restart.
+2. Either open `index.html` directly in your browser or start a quick server with `python3 -m http.server` and visit `http://localhost:8000`.
+3. Drag or swipe the card left/right to answer.
+4. Use **Try Again** or **Quit** to restart when you lose.
 
-Screenshots below show a glimpse of the interface:
+## Contributing Questions
+Question data lives in `questions.js` and the `new_questions_batch*.js` files. Each file exports an array of objects:
 
-![Elon happy](elon_musk_happy.png)
-![Elon angry](elon_musk_angry.png)
+```javascript
+{
+  text: "Should Tesla make a rocket car?",
+  rightResponse: "'Full send!'",
+  leftResponse: "'Maybe keep the wheels on the ground.'",
+  impact: {
+    right: { spacex: 5, tesla: 10 },
+    left: { spacex: -5, tesla: -5 }
+  }
+}
+```
 
-This project is a parody and is provided for entertainment. It is licensed under the [Apache License 2.0](LICENSE).
+Add your question to an existing file or create a new one following the same pattern, then include that script in `index.html`.
+
+## Screenshots
+
+![Gameplay screenshot of Elon smiling](elon_musk_happy.png)
+![Gameplay screenshot of Elon angry](elon_musk_angry.png)
+
+Licensed under the [Apache License 2.0](LICENSE).
+

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Elon Musk Simulator is a parody swipe game where you balance Musk's many ventures.">
+    <meta name="keywords" content="Elon Musk, simulator, parody game, SpaceX, Tesla, satire">
     <title>Elon Musk Simulator</title>
     <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary
- rewrite README with a project overview, gameplay and local setup instructions
- explain how to add new questions
- add screenshots with alt text
- mention the Apache 2.0 license and parody nature
- include SEO meta description and keywords in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847eea66a9c832fb45459ddafd862da