### PR TITLE
Add ESLint, Prettier and lint workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "globals": {
+    "allQuestions": "readonly",
+    "questions": "readonly",
+    "new_questions_batch1": "readonly",
+    "new_questions_batch2": "readonly",
+    "new_questions_batch3": "readonly",
+    "new_questions_batch4": "readonly",
+    "new_questions_batch5": "readonly"
+  },
+  "rules": {
+    "no-unused-vars": "off"
+  }
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Run ESLint
+        run: npx -y eslint@8 .

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}


### PR DESCRIPTION
## Summary
- configure ESLint for browser/Node ES2021 code
- add Prettier formatting rules
- run ESLint on pull requests via GitHub Actions

## Testing
- `npx -y eslint@8 .`

------
https://chatgpt.com/codex/tasks/task_e_6847eea992f4832f981a2432deb53789