### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -13,4 +13,9 @@ Screenshots below show a glimpse of the interface:
 ![Elon happy](elon_musk_happy.png)
 ![Elon angry](elon_musk_angry.png)
 
+## Live Demo
+
+Play it online here:
+<https://muratcangencturk.github.io/elonmusksimulator/>
+
 This project is a parody and is provided for entertainment. It is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary
- add workflow to deploy the static site using GitHub Pages
- document live demo URL in the README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6847eeae9af0832f8c96f31272dc0448