### PR TITLE
Add internationalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 ## Playing the Game
 1. Clone or download this repository.
 2. Open `index.html` in a modern web browser (double click the file or serve it locally).
-3. Drag/swipe the card left or right to pick an answer. Keep the meters from maxing out or dropping to zero to survive.
-4. If you fail, hit **Try Again** or **Quit** to restart.
+3. Choose your language from the dropdown at the top.
+4. Drag/swipe the card left or right to pick an answer. Keep the meters from maxing out or dropping to zero to survive.
+5. If you fail, hit **Try Again** or **Quit** to restart.
 
 Screenshots below show a glimpse of the interface:
 

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,32 @@
+let currentLanguage = 'en';
+
+function loadLanguage(lang) {
+  const t = translations[lang] || translations['en'];
+  currentLanguage = lang;
+  if (document.getElementById('title')) {
+    document.getElementById('title').textContent = t.title;
+  }
+  if (document.getElementById('subtitle')) {
+    document.getElementById('subtitle').textContent = t.subtitle;
+  }
+  if (document.getElementById('game-over-title')) {
+    document.getElementById('game-over-title').textContent = t.gameOverTitle;
+  }
+  if (document.getElementById('game-over-message')) {
+    document.getElementById('game-over-message').textContent = t.gameOverMessage;
+  }
+  if (document.getElementById('restart-button')) {
+    document.getElementById('restart-button').textContent = t.tryAgain;
+  }
+  if (document.getElementById('quit-button')) {
+    document.getElementById('quit-button').textContent = t.quit;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const selector = document.getElementById('language-select');
+  if (selector) {
+    selector.addEventListener('change', (e) => loadLanguage(e.target.value));
+  }
+  loadLanguage(currentLanguage);
+});

--- a/index.html
+++ b/index.html
@@ -9,8 +9,12 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>ELON MUSK SIMULATOR</h1>
-            <p>This is Elon Musk!</p>
+            <h1 id="title">ELON MUSK SIMULATOR</h1>
+            <p id="subtitle">This is Elon Musk!</p>
+            <select id="language-select">
+                <option value="en">English</option>
+                <option value="es">Español</option>
+            </select>
         </div>
         
         <div class="vitals" id="vitals">
@@ -26,8 +30,8 @@
     </div>
 
     <div class="game-over" id="game-over">
-        <h2>Game Over: Elon has lost interest in you...</h2>
-        <p>Your decisions have led to a catastrophic failure in one of Elon's ventures.</p>
+        <h2 id="game-over-title">Game Over: Elon has lost interest in you...</h2>
+        <p id="game-over-message">Your decisions have led to a catastrophic failure in one of Elon's ventures.</p>
         <div class="control-buttons">
             <button class="control-button restart-button" id="restart-button">Try Again</button>
             <button class="control-button quit-button" id="quit-button">Quit</button>
@@ -40,6 +44,8 @@
     <script src="new_questions_batch3.js"></script>
     <script src="new_questions_batch4.js"></script>
     <script src="new_questions_batch5.js"></script>
+    <script src="translations.js"></script>
+    <script src="i18n.js"></script>
     <script src="main.js" defer></script>
 </body>
 </html>

--- a/translations.js
+++ b/translations.js
@@ -1,0 +1,18 @@
+const translations = {
+  en: {
+    title: "ELON MUSK SIMULATOR",
+    subtitle: "This is Elon Musk!",
+    gameOverTitle: "Game Over: Elon has lost interest in you...",
+    gameOverMessage: "Your decisions have led to a catastrophic failure in one of Elon's ventures.",
+    tryAgain: "Try Again",
+    quit: "Quit"
+  },
+  es: {
+    title: "SIMULADOR DE ELON MUSK",
+    subtitle: "\u00a1Este es Elon Musk!",
+    gameOverTitle: "Fin del Juego: Elon ha perdido inter\u00e9s en ti...",
+    gameOverMessage: "Tus decisiones han llevado a un fracaso catastr\u00f3fico en una de las empresas de Elon.",
+    tryAgain: "Intentar de nuevo",
+    quit: "Salir"
+  }
+};


### PR DESCRIPTION
## Summary
- localize textual content for buttons and messages
- add language dropdown and translation loading logic
- document language selection in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847eeafd6f4832fa4bbf2ad89c3b10d