### PR TITLE
Disable mobile translation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="google" content="notranslate">
     <meta name="description" content="Elon Musk Simulator is a parody browser game where your decisions keep his ventures afloat.">
     <title>Elon Musk Simulator</title>
     <meta property="og:title" content="Elon Musk Simulator">


### PR DESCRIPTION
## Summary
- add a `notranslate` meta tag in `index.html` to prevent browsers from injecting the language selection bar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684805cc4d70832f9cf11a80abbdb1e2