### PR TITLE
Fix language toggle visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -348,10 +348,10 @@ body {
 }
 
 .language-toggle {
-    position: absolute;
+    position: fixed;
     top: 10px;
     left: 10px;
-    z-index: 10;
+    z-index: 100;
 }
 
 .language-toggle button {
@@ -362,6 +362,7 @@ body {
     background: #fff;
     color: #000;
     cursor: pointer;
+    font-size: 0.8rem;
 }
 
 .language-toggle button:focus {


### PR DESCRIPTION
## Summary
- place language buttons at fixed top-left of the viewport
- ensure buttons are smaller and always visible

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5ef4ca4832f99d56a9ea0b3f359