### PR TITLE
Add normalize and categorize scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ The game loads these files on demand so only the necessary categories are fetche
 Screenshots below show a glimpse of the interface:
 
 ```bash
-node normalize_questions.js
+npm run normalize
 ```
 
 The script scans `questions.json` and all `new_questions_batch*.json` files in
 the repository, swaps responses when the left choice carries a positive impact
 and the right choice a negative one, then writes the normalized JSON back to
 disk.
+
+## Developer Scripts
+
+Run `npm run normalize` anytime you add new questions to ensure left/right
+responses follow the expected structure. Use `npm run categorize` to generate
+`tech.json`, `politics.json` and `misc.json` from the question files.
 
 ## Live Demo
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "**Elon Musk Simulator** is a tongue-in-cheek browser game where you try to keep Elon's many ventures afloat. Each turn presents a question with absurd proposals. Swipe **left** or **right** to answer and balance the vital stats for SpaceX, Tesla, and other Musk projects. Let any vital reach 0 or 100 and it's game over!",
   "main": "main.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "normalize": "node normalize_questions.js",
+    "categorize": "node categorize_questions.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add question utilities to npm scripts
- explain how to run these scripts in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aee0f9558832fa54c7e5de33aecb2