### PR TITLE
Update service worker for new question files

### DIFF
--- a/__tests__/service-worker.test.js
+++ b/__tests__/service-worker.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const swPath = path.resolve(__dirname, '..', 'sw.js');
+const swText = fs.readFileSync(swPath, 'utf8');
+
+describe('service worker asset list', () => {
+  const assets = [
+    'tech.json',
+    'tech_tr.json',
+    'politics.json',
+    'politics_tr.json',
+    'misc.json',
+    'misc_tr.json'
+  ];
+
+  test('includes category question files', () => {
+    assets.forEach(file => {
+      expect(swText).toContain(`'${file}'`);
+    });
+  });
+});

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'elon-sim-cache-v1';
+const CACHE_NAME = 'elon-sim-cache-v2';
 const ASSETS = [
   './',
   'index.html',
@@ -10,6 +10,12 @@ const ASSETS = [
   'new_questions_batch3.json',
   'new_questions_batch4.json',
   'new_questions_batch5.json',
+  'tech.json',
+  'tech_tr.json',
+  'politics.json',
+  'politics_tr.json',
+  'misc.json',
+  'misc_tr.json',
   'elon_musk_cartoon.png',
   'elon_musk_happy.png',
   'elon_musk_angry.png',


### PR DESCRIPTION
## Summary
- cache question category JSON files in service worker
- bump cache name to force reload
- test service worker asset list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af43b820c832f805f0e9d2ac15584