### PR TITLE
Fix JSON import for Turkish questions

### DIFF
--- a/main.js
+++ b/main.js
@@ -641,7 +641,10 @@ async function loadCategory(name) {
     } catch (err) {
         console.warn(`Fetch failed for ${cat.file[getLanguage()]}, attempting module import`, err);
         try {
-            const module = await import(/* webpackIgnore: true */ `./${cat.file[getLanguage()]}`);
+            const module = await import(
+                /* webpackIgnore: true */ `./${cat.file[getLanguage()]}`,
+                { assert: { type: 'json' } }
+            );
             const valid = filterValidQuestions(module.default);
             cat.questions = addInnovationImpactToQuestions(valid);
             cat.loaded = true;


### PR DESCRIPTION
## Summary
- ensure fallback JSON import in `loadCategory` uses `assert { type: 'json' }`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c06eec710832f9c4ad6f9d78c9f81